### PR TITLE
allow for dynamically updating DATA_END_DATE

### DIFF
--- a/geothermalsite/dashboard/forms.py
+++ b/geothermalsite/dashboard/forms.py
@@ -1,8 +1,8 @@
 from django import forms
+from datetime import datetime, timedelta
 from .helper.constants import (
     DATA_START_DATE,
     DATA_END_DATE,
-    MONTH_BEFORE_END,
     STARTING_DEPTH,
 )
 
@@ -20,6 +20,17 @@ class TempVsTimeForm(forms.Form):
     depth : django.forms.IntegerField
         the integer depth a user may select to query
     """
+
+    # if the end date is dynamic, then we need to update the DATA_END_DATE
+    # to yesterday. In either case, we need to define MONTH_BEFORE_END as
+    # well.
+    global DATA_END_DATE
+    if DATA_END_DATE == "yesterday":
+        DATA_END_DATE = (datetime.now() - timedelta(days=1)).strftime("%m/%d/%Y")
+
+    MONTH_BEFORE_END = (
+        datetime.strptime(DATA_END_DATE, "%m/%d/%Y") - timedelta(days=30)
+    ).strftime("%m/%d/%Y")
 
     tempVsTimeBoreholeNumber = forms.ChoiceField(
         label="Borehole",
@@ -132,6 +143,17 @@ class TemperatureProfileForm(forms.Form):
     timestamp : django.forms.CharField
         the time stamp to query data at, with a minimum at the data start date
     """
+
+    # if the end date is dynamic, then we need to update the DATA_END_DATE
+    # to yesterday. In either case, we need to define MONTH_BEFORE_END as
+    # well.
+    global DATA_END_DATE
+    if DATA_END_DATE == "yesterday":
+        DATA_END_DATE = (datetime.now() - timedelta(days=1)).strftime("%m/%d/%Y")
+
+    MONTH_BEFORE_END = (
+        datetime.strptime(DATA_END_DATE, "%m/%d/%Y") - timedelta(days=30)
+    ).strftime("%m/%d/%Y")
 
     tempProfileBoreholeNumber = forms.ChoiceField(
         label="Borehole",

--- a/geothermalsite/dashboard/helper/constants.py
+++ b/geothermalsite/dashboard/helper/constants.py
@@ -2,10 +2,14 @@ from datetime import datetime, timedelta
 
 
 DATA_START_DATE = "02/27/2019"
-DATA_END_DATE = "09/04/2022"
-MONTH_BEFORE_END = (
-    datetime.strptime(DATA_END_DATE, "%m/%d/%Y") - timedelta(days=30)
-).strftime("%m/%d/%Y")
+
+# When set to "today", the most current data will be available.
+# This can be changed to a date in the same format as DATA_START_DATE
+# if you would like to hard-code the last day that data will be available.
+# NOTE: we set this to "yesterday" rather than "today" since we don't want users
+# to be able to query data from the current day when there might not be any
+# data at certain times.
+DATA_END_DATE = "yesterday"
 
 STARTING_DEPTH = 10
 

--- a/geothermalsite/dashboard/helper/renderFunctions.py
+++ b/geothermalsite/dashboard/helper/renderFunctions.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from django.http import HttpRequest
 from ..forms import TempVsTimeForm, TemperatureProfileForm
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from .constants import DATA_END_DATE, DATA_START_DATE
 from .visualization import (
@@ -48,6 +48,11 @@ def _getPageContext(
     type: str,
     units: str,
 ) -> dict():
+
+    global DATA_END_DATE
+    if DATA_END_DATE == "yesterday":
+        DATA_END_DATE = (datetime.now() - timedelta(days=1)).strftime("%m/%d/%Y")
+
     return {
         "temperatureProfileForm": TemperatureProfileForm(),
         "tempOverTimeForm": TempVsTimeForm(),


### PR DESCRIPTION
This change addresses a concern that Bruce Duffy brought up, which is that the DATA_END_DATE constant was hard-coded in `constants.py`, which prevented users from seeing the most up-to-date data (assuming no outages). Now, DATA_END_DATE is set to "yesterday", and all instances where DATA_END_DATE is used first checks if it's set to "yesterday" (as opposed to a real date), updates it to yesterday's date if so, and updates MONTH_BEFORE_END to be 30 days prior to the (potentially updated) DATA_END_DATE. If DATA_END_DATE is simply a date, then that date is used and MONTH_BEFORE_END is calculated the same way.